### PR TITLE
STOR-5120 - Query builder now supplies the select statement to gorm

### DIFF
--- a/query/config.go
+++ b/query/config.go
@@ -4,10 +4,11 @@ import "errors"
 
 const (
 	// fields in the struct tag.
-	sortTag   = "sort"
-	splitTag  = "split"
-	filterTag = "filter"
-	paramTag  = "param"
+	sortTag     = "sort"
+	splitTag    = "split"
+	filterTag   = "filter"
+	paramTag    = "param"
+	detailedTag = "detailed"
 	// search param in query string.
 	searchParam = "search"
 	// operators in query string.
@@ -54,6 +55,8 @@ type Config struct {
 	OffsetParam string
 	// SearchOperator used to combine search condition together. defaults to "AND".
 	SearchOperator string
+	// OnlySelectNonDetailedFields - if true will select only the non 'detailed' fields.
+	OnlySelectNonDetailedFields bool
 }
 
 func (c *Config) defaults() error {

--- a/query/example_test.go
+++ b/query/example_test.go
@@ -4,18 +4,20 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"testing"
 	"time"
 )
 
-func ExampleBuilder_Parse() {
+func TestExampleBuilder_Parse(t *testing.T) {
 	b, err := NewBuilder(&Config{
 		Model: struct {
 			Name      string    `query:"sort,filter"`
 			Age       int       `query:"filter"`
-			CreatedAt time.Time `query:"sort,filter"`
+			CreatedAt time.Time `query:"sort,filter,detailed"`
 		}{},
 		DefaultSort:  "created_at desc",
 		DefaultLimit: 10,
+		OnlySelectNonDetailedFields: true,
 	})
 	if err != nil {
 		log.Fatal("failed to initialize builder", err)


### PR DESCRIPTION
By default gorm uses "select *", unless the select statement is
explicitly supplied.
Query builder uses the model to construct the select statement which
allows selecting only fields that are in the model.
This commit also added an optional 'query' tag - 'detailed'
If the Query builder is configured in 'OnlySelectNonDetailedFields'
mode, it will not add the fields tagged with 'detailed' to the select
statement thus allowing the user to avoid selecting costly fields (such
as TEXT fields) if not required