### PR TITLE
multiple lines comment on swagger description

### DIFF
--- a/templates/client/client.gotmpl
+++ b/templates/client/client.gotmpl
@@ -29,8 +29,10 @@ import (
 // API is the interface of the {{ humanize .Name }} client
 type API interface {
 {{ range .Operations -}}
-  // {{ pascalize .Name }} {{ if .Summary }}{{ pluralizeFirstWord (humanize .Summary) }}{{ if .Description }}
-  // {{ blockcomment .Description }}{{ end }}{{ else if .Description}}{{ blockcomment .Description }}{{ else }}{{ humanize .Name }} API{{ end }}
+  /*
+{{ pascalize .Name }} {{ if .Summary }}{{ pluralizeFirstWord (humanize .Summary) }}{{ if .Description }}
+{{ blockcomment .Description }}{{ end }}{{ else if .Description}}{{ blockcomment .Description }}{{ else }}{{ humanize .Name }} API{{ end }}
+  */
   {{ pascalize .Name }}(ctx context.Context, params *{{ pascalize .Name }}Params{{ if .HasStreamingResponse }}, writer io.Writer{{ end }}) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }}
 {{ end -}}
 }


### PR DESCRIPTION
auto generated swagger from hammock may contain multiple lines description
this description will have a comment only on the first line, so putting the description under /* */ comment will solve it