### PR TITLE
Fix alias line so that swagger can be run in a different directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ a standard `http.Handler`
 Using the docker container, add the following alias to a `~/.bashrc` or similar
 
 ```bash
-alias swagger="docker run --rm -e GOPATH=/go -v ${HOME}:${HOME} -w $(pwd) -u $(id -u):$(id -g) stratoscale/swagger:v1.0.9"
+alias swagger="docker run --rm -e GOPATH=/go -v ${HOME}:${HOME} -w "'$(pwd)'" -u $(id -u):$(id -g) stratoscale/swagger:v1.0.9"
 ```
 
 Then, use the `swagger` command:


### PR DESCRIPTION
Otherwise, the pwd command is only executed once, and running swagger on a different directory will fail.