### PR TITLE
fixed template rendering with current version of go-swagger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/goswagger/swagger:v0.17.0
+FROM quay.io/goswagger/swagger:v0.25.0
 ADD ./templates /templates
 ADD ./entrypoint.sh /entrypoint.sh
 

--- a/templates/server/configureapi.gotmpl
+++ b/templates/server/configureapi.gotmpl
@@ -139,7 +139,7 @@ func Handler(c Config) (http.Handler, error) {
 	{{ end -}}
 
 	{{ range .Operations -}}
-	api.{{if ne .Package $package}}{{pascalize .Package}}{{end}}{{ pascalize .Name }}Handler = {{.Package}}.{{ pascalize .Name }}HandlerFunc(func({{ if .WithContext }}ctx context.Context, {{ end }}params {{.Package}}.{{ pascalize .Name }}Params{{if .Authorized}}, principal interface{}{{end}}) middleware.Responder {
+	api.{{if ne .Package $package}}{{pascalize .Package}}{{end}}{{ pascalize .Name }}Handler = {{.Package}}.{{ pascalize .Name }}HandlerFunc(func(params {{.Package}}.{{ pascalize .Name }}Params{{if .Authorized}}, principal interface{}{{end}}) middleware.Responder {
 		ctx := params.HTTPRequest.Context()
 		{{ if .Authorized -}}
 		ctx = storeAuth(ctx, principal)


### PR DESCRIPTION
Recently I started getting these errors when I try to compile code generated with stratoscale/swagger:

```
restapi/operations/foo/foo_create_parameters.go:56:38: not enough arguments in call to "github.com/go-openapi/errors".Required
        have (string, string)
        want (string, string, interface {})
```

A breaking change was made to [go-openapi/errors](https://github.com/go-openapi/errors) in the summer of 2020:
  - https://github.com/go-openapi/errors/issues/22
  - https://github.com/go-openapi/errors/issues/25

In order for go-swagger-generated code to compile properly, you need to use at least version v0.24.0 of [go-swagger](https://github.com/go-swagger):
  - https://github.com/go-swagger/go-swagger/issues/2361

Unfortunately, stratoscale/swagger is not compatible with the latest versions of go-swagger; the template fails to render with this error:

```
failed rendering template data for configure: template execution failed for template configure: template: serverConfigureapi:142:149: executing "serverConfigureapi" at <.WithContext>: can't evaluate field WithContext in type generator.GenOperation
```

I fixed this by removing the `{{ if .WithContext }}` conditional from the `Operations` block in `server/configureapi.gotmpl`.  The template renders and the resulting code is compatible with the latest go-openapi/errors.

I'm not clear on the implications of removing the `WithContext` conditional.  It's possible that other changes need to be made to the templates to compensate for the removal of this block.  I'll leave that up to the experts.  But I'd greatly appreciate a 1.0.28 release with a fix for this incompatibility.